### PR TITLE
remove Value::RawString, Type::RawString, SyntaxShape::RawString

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -294,7 +294,6 @@ fn describe_value(
         | Value::Range { .. }
         | Value::String { .. }
         | Value::Glob { .. }
-        | Value::RawString { .. }
         | Value::Nothing { .. } => Value::record(
             record!(
                 "type" => Value::string(value.get_type().to_string(), head),

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -263,7 +263,7 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
                     }
                 },
             },
-            Value::String { val, .. } | Value::Glob { val, .. } | Value::RawString { val, .. } => {
+            Value::String { val, .. } | Value::Glob { val, .. } => {
                 write!(f, "{:?}", val)
             }
             Value::Record { val, .. } => {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -102,7 +102,6 @@ impl<'a> StyleComputer<'a> {
             Value::Float { .. } => TextStyle::with_style(Right, s),
             Value::String { .. } => TextStyle::with_style(Left, s),
             Value::Glob { .. } => TextStyle::with_style(Left, s),
-            Value::RawString { .. } => TextStyle::with_style(Left, s),
             Value::Nothing { .. } => TextStyle::with_style(Left, s),
             Value::Binary { .. } => TextStyle::with_style(Left, s),
             Value::CellPath { .. } => TextStyle::with_style(Left, s),

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -348,7 +348,6 @@ fn insert_value(
 fn nu_value_to_sqlite_type(val: &Value) -> Result<&'static str, ShellError> {
     match val.get_type() {
         Type::String => Ok("TEXT"),
-        Type::RawString => Ok("TEXT"),
         Type::Int => Ok("INTEGER"),
         Type::Float => Ok("REAL"),
         Type::Number => Ok("REAL"),

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -258,7 +258,6 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
         Value::Range { val, .. } => val.to_string(),
         Value::String { val, .. } => val.clone(),
         Value::Glob { val, .. } => val.clone(),
-        Value::RawString { val, .. } => val.clone(),
         Value::List { vals: val, .. } => format!(
             "[{}]",
             val.iter()

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -527,7 +527,6 @@ fn value_should_be_printed(
         | Value::Error { .. } => term_equals_value(term, &lower_value, span),
         Value::String { .. }
         | Value::Glob { .. }
-        | Value::RawString { .. }
         | Value::List { .. }
         | Value::CellPath { .. }
         | Value::Custom { .. } => term_contains_value(term, &lower_value, span),

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -112,7 +112,6 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
         Value::Nothing { .. } => nu_json::Value::Null,
         Value::String { val, .. } => nu_json::Value::String(val.to_string()),
         Value::Glob { val, .. } => nu_json::Value::String(val.to_string()),
-        Value::RawString { val, .. } => nu_json::Value::String(val.to_string()),
         Value::CellPath { val, .. } => nu_json::Value::Array(
             val.members
                 .iter()

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -119,7 +119,6 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         Value::Range { val, .. } => val.to_string(),
         Value::String { val, .. } => val,
         Value::Glob { val, .. } => val,
-        Value::RawString { val, .. } => val,
         Value::List { vals: val, .. } => val
             .into_iter()
             .map(|x| local_into_string(x, ", ", config))

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -54,9 +54,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         }
         Value::Range { .. } => toml::Value::String("<Range>".to_string()),
         Value::Float { val, .. } => toml::Value::Float(*val),
-        Value::String { val, .. } | Value::Glob { val, .. } | Value::RawString { val, .. } => {
-            toml::Value::String(val.clone())
-        }
+        Value::String { val, .. } | Value::Glob { val, .. } => toml::Value::String(val.clone()),
         Value::Record { val, .. } => {
             let mut m = toml::map::Map::new();
             for (k, v) in &**val {

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -49,7 +49,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         Value::Date { val, .. } => serde_yaml::Value::String(val.to_string()),
         Value::Range { .. } => serde_yaml::Value::Null,
         Value::Float { val, .. } => serde_yaml::Value::Number(serde_yaml::Number::from(*val)),
-        Value::String { val, .. } | Value::Glob { val, .. } | Value::RawString { val, .. } => {
+        Value::String { val, .. } | Value::Glob { val, .. } => {
             serde_yaml::Value::String(val.clone())
         }
         Value::Record { val, .. } => {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3341,7 +3341,6 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 }
 
 pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
-    trace!("parsing source");
     let spans = &lite_command.parts;
     let name = working_set.get_span_contents(spans[0]);
 

--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -68,7 +68,6 @@ pub fn parse_shape_name(
         _ if bytes.starts_with(b"table") => {
             parse_collection_shape(working_set, bytes, span, use_loc)
         }
-        b"raw-string" => SyntaxShape::RawString,
         _ => {
             if bytes.contains(&b'@') {
                 let mut split = bytes.splitn(2, |b| b == &b'@');

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -583,7 +583,6 @@ pub fn parse_multispan_value(
     spans_idx: &mut usize,
     shape: &SyntaxShape,
 ) -> Expression {
-    trace!("parse multispan value");
     match shape {
         SyntaxShape::VarWithOptType => {
             trace!("parsing: var with opt type");
@@ -1622,7 +1621,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
         Expression {
             expr: Expr::RawString(token),
             span,
-            ty: Type::RawString,
+            ty: Type::String,
             custom_completion: None,
         }
     } else {
@@ -6306,7 +6305,6 @@ pub fn parse(
     contents: &[u8],
     scoped: bool,
 ) -> Arc<Block> {
-    trace!("parse");
     let name = match fname {
         Some(fname) => {
             // use the canonical name for this filename

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -36,7 +36,7 @@ pub enum Expr {
     Directory(String, bool),
     GlobPattern(String, bool),
     String(String),
-    RawString(String),
+    RawString(String), // Introduce RawString mainly for different highliting to String.
     CellPath(CellPath),
     FullCellPath(Box<FullCellPath>),
     ImportPattern(Box<ImportPattern>),

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -133,7 +133,8 @@ pub trait Eval {
             }
             Expr::Keyword(kw) => Self::eval::<D>(state, mut_state, &kw.expr),
             Expr::String(s) => Ok(Value::string(s.clone(), expr.span)),
-            Expr::RawString(s) => Ok(Value::raw_string(s.clone(), expr.span)),
+            // RawString expression is actually a value of string.
+            Expr::RawString(s) => Ok(Value::string(s.clone(), expr.span)),
             Expr::Nothing => Ok(Value::nothing(expr.span)),
             Expr::ValueWithUnit(value) => match Self::eval::<D>(state, mut_state, &value.expr)? {
                 Value::Int { val, .. } => value.unit.item.build_value(val, value.unit.span),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -110,9 +110,6 @@ pub enum SyntaxShape {
     /// Strings and string-like bare words are allowed
     String,
 
-    /// RawStrings are allowed, e.g. `r"some string"`
-    RawString,
-
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table(Vec<(String, SyntaxShape)>),
 
@@ -174,7 +171,6 @@ impl SyntaxShape {
             SyntaxShape::Boolean => Type::Bool,
             SyntaxShape::Signature => Type::Signature,
             SyntaxShape::String => Type::String,
-            SyntaxShape::RawString => Type::RawString,
             SyntaxShape::Table(columns) => Type::Table(mk_ty(columns)),
             SyntaxShape::VarWithOptType => Type::Any,
         }
@@ -196,7 +192,6 @@ impl Display for SyntaxShape {
             }
             SyntaxShape::Any => write!(f, "any"),
             SyntaxShape::String => write!(f, "string"),
-            SyntaxShape::RawString => write!(f, "rawstring"),
             SyntaxShape::CellPath => write!(f, "cell-path"),
             SyntaxShape::FullCellPath => write!(f, "cell-path"),
             SyntaxShape::Number => write!(f, "number"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -31,7 +31,6 @@ pub enum Type {
     Record(Box<[(String, Type)]>),
     Signature,
     String,
-    RawString,
     Glob,
     Table(Box<[(String, Type)]>),
 }
@@ -103,7 +102,6 @@ impl Type {
             Type::Range => SyntaxShape::Range,
             Type::Bool => SyntaxShape::Boolean,
             Type::String => SyntaxShape::String,
-            Type::RawString => SyntaxShape::RawString,
             Type::Block => SyntaxShape::Block, // FIXME needs more accuracy
             Type::Closure => SyntaxShape::Closure(None), // FIXME needs more accuracy
             Type::CellPath => SyntaxShape::CellPath,
@@ -145,7 +143,6 @@ impl Type {
             Type::Nothing => String::from("nothing"),
             Type::Number => String::from("number"),
             Type::String => String::from("string"),
-            Type::RawString => String::from("raw-string"),
             Type::ListStream => String::from("list-stream"),
             Type::Any => String::from("any"),
             Type::Error => String::from("error"),
@@ -204,7 +201,6 @@ impl Display for Type {
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),
             Type::String => write!(f, "string"),
-            Type::RawString => write!(f, "raw-string"),
             Type::ListStream => write!(f, "list-stream"),
             Type::Any => write!(f, "any"),
             Type::Error => write!(f, "error"),

--- a/crates/nuon/src/from.rs
+++ b/crates/nuon/src/from.rs
@@ -320,7 +320,7 @@ fn convert_to_value(
             span: expr.span,
         }),
         Expr::String(s) => Ok(Value::string(s, span)),
-        Expr::RawString(s) => Ok(Value::raw_string(s, span)),
+        Expr::RawString(s) => Ok(Value::string(s, span)),
         Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError {
             src: original_text.to_string(),
             error: "Error when loading".into(),

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -228,7 +228,6 @@ fn value_to_string(
         // All strings outside data structures are quoted because they are in 'command position'
         // (could be mistaken for commands by the Nu parser)
         Value::String { val, .. } => Ok(escape_quote_string(val)),
-        Value::RawString { val, .. } => Ok(escape_quote_string(val)),
         Value::Glob { val, .. } => Ok(escape_quote_string(val)),
     }
 }


### PR DESCRIPTION
This pr is going to remove these things to make raw string works with any string commands, like `str length`.

And it also keep raw string have a different highlight color to normal string.

