### PR TITLE
Fix raw string with let like: let x = r@'abc'@

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -102,4 +102,7 @@ fn let_raw_string() {
 
     let actual = nu!(r#"let x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+
+    let actual = nu!(r#"let x = r@'abc'@; $x"#);
+    assert_eq!(actual.out, "abc");
 }

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -136,4 +136,7 @@ fn mut_raw_string() {
 
     let actual = nu!(r#"mut x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+
+    let actual = nu!(r#"mut x = r@'abc'@; $x"#);
+    assert_eq!(actual.out, "abc");
 }

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -527,7 +527,7 @@ fn lex_internal(
                 //      ^
                 //      ^
                 //   curr_offset
-                curr_offset += start + prefix_at_cnt + 1;
+                curr_offset += prefix_at_cnt + 1;
                 let mut matches = false;
                 let mut meet_quote = false;
                 while let Some(ch) = input.get(curr_offset) {

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -528,8 +528,16 @@ fn lex_internal(
                 //      ^
                 //   curr_offset
                 curr_offset += prefix_at_cnt + 1;
+                // the next one should be a single quote.
+                if input.get(curr_offset) != Some(&b'\'') {
+                    error = Some(ParseError::Expected(
+                        "'",
+                        Span::new(span_offset + curr_offset, span_offset + curr_offset + 1),
+                    ));
+                }
+
+                curr_offset += 1;
                 let mut matches = false;
-                let mut meet_quote = false;
                 while let Some(ch) = input.get(curr_offset) {
                     // check for postfix '@@@
                     if *ch == b'@' {
@@ -540,8 +548,6 @@ fn lex_internal(
                             curr_offset += 1;
                             break;
                         }
-                    } else if *ch == b'\'' {
-                        meet_quote = true;
                     }
                     curr_offset += 1
                 }
@@ -550,12 +556,6 @@ fn lex_internal(
                         TokenContents::Item,
                         Span::new(span_offset + start, span_offset + curr_offset),
                     ));
-                } else if !meet_quote {
-                    let quote_pos = span_offset + start + prefix_at_cnt + 1;
-                    error = Some(ParseError::Expected(
-                        "'",
-                        Span::new(quote_pos, quote_pos + 1),
-                    ))
                 } else if error.is_none() {
                     error = Some(ParseError::UnexpectedEof(
                         "@".to_string(),

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -411,4 +411,7 @@ fn const_raw_string() {
 
     let actual = nu!(r#"const x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+
+    let actual = nu!(r#"const x = r@'abc'@; $x"#);
+    assert_eq!(actual.out, "abc");
 }


### PR DESCRIPTION
Sorry I leave a bug in the original raw string implementation, it's about lexing inputs.

Currently nushell will failed with the following:
```nushell
let x = r@'abc'@
```

It will return an strange error.    This pr is going to fix it.
