### PR TITLE
using r# rather than r@

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -94,15 +94,15 @@ fn let_glob_type() {
 
 #[test]
 fn let_raw_string() {
-    let actual = nu!(r#"let x = r@'abcde""fghi"''''jkl'@; $x"#);
+    let actual = nu!(r#"let x = r#'abcde""fghi"''''jkl'#; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"''''jkl"#);
 
-    let actual = nu!(r#"let x = r@@'abcde""fghi"''''@jkl'@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"''''@jkl"#);
+    let actual = nu!(r#"let x = r##'abcde""fghi"''''#jkl'##; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"''''#jkl"#);
 
-    let actual = nu!(r#"let x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+    let actual = nu!(r#"let x = r###'abcde""fghi"'''##'#jkl'###; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"'''##'#jkl"#);
 
-    let actual = nu!(r#"let x = r@'abc'@; $x"#);
+    let actual = nu!(r#"let x = r#'abc'#; $x"#);
     assert_eq!(actual.out, "abc");
 }

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -128,15 +128,15 @@ fn mut_glob_type() {
 
 #[test]
 fn mut_raw_string() {
-    let actual = nu!(r#"mut x = r@'abcde""fghi"''''jkl'@; $x"#);
+    let actual = nu!(r#"mut x = r#'abcde""fghi"''''jkl'#; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"''''jkl"#);
 
-    let actual = nu!(r#"mut x = r@@'abcde""fghi"''''@jkl'@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"''''@jkl"#);
+    let actual = nu!(r#"mut x = r##'abcde""fghi"''''#jkl'##; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"''''#jkl"#);
 
-    let actual = nu!(r#"mut x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+    let actual = nu!(r#"mut x = r###'abcde""fghi"'''##'#jkl'###; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"'''##'#jkl"#);
 
-    let actual = nu!(r#"mut x = r@'abc'@; $x"#);
+    let actual = nu!(r#"mut x = r#'abc'#; $x"#);
     assert_eq!(actual.out, "abc");
 }

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -504,30 +504,30 @@ fn lex_internal(
             // If the next character is non-newline whitespace, skip it.
             curr_offset += 1;
         } else if c == b'r' {
-            // A raw string literal looks like `echo r@'Look, I can use 'single quotes'!'@`
-            // If the next character is `@` we're probably looking at a raw string literal
-            // so we need to read all the text until we find a closing `@`. This raw string
+            // A raw string literal looks like `echo r#'Look, I can use 'single quotes'!'#`
+            // If the next character is `#` we're probably looking at a raw string literal
+            // so we need to read all the text until we find a closing `#`. This raw string
             // can contain any character, including newlines and double quotes without needing
             // to escape them.
             //
-            // A raw string can contain many `@` as prefix,
-            // incase if there is a `'@` or `@'` in the string itself.
-            // E.g: r@@'I can use '@' in a raw string'@@
-            let mut prefix_at_cnt = 0;
+            // A raw string can contain many `#` as prefix,
+            // incase if there is a `'#` or `#'` in the string itself.
+            // E.g: r##'I can use '#' in a raw string'##
+            let mut prefix_sharp_cnt = 0;
             let start = curr_offset;
-            while let Some(b'@') = input.get(start + prefix_at_cnt + 1) {
-                prefix_at_cnt += 1;
+            while let Some(b'#') = input.get(start + prefix_sharp_cnt + 1) {
+                prefix_sharp_cnt += 1;
             }
 
-            if prefix_at_cnt != 0 {
-                // curr_offset is the character `r`, we need to move forward and skip all `@`
+            if prefix_sharp_cnt != 0 {
+                // curr_offset is the character `r`, we need to move forward and skip all `#`
                 // characters.
                 //
-                // e.g: r@@@'<body>
+                // e.g: r###'<body>
                 //      ^
                 //      ^
                 //   curr_offset
-                curr_offset += prefix_at_cnt + 1;
+                curr_offset += prefix_sharp_cnt + 1;
                 // the next one should be a single quote.
                 if input.get(curr_offset) != Some(&b'\'') {
                     error = Some(ParseError::Expected(
@@ -539,11 +539,11 @@ fn lex_internal(
                 curr_offset += 1;
                 let mut matches = false;
                 while let Some(ch) = input.get(curr_offset) {
-                    // check for postfix '@@@
-                    if *ch == b'@' {
-                        let start_ch = input[curr_offset - prefix_at_cnt];
-                        let postfix = &input[curr_offset - prefix_at_cnt + 1..=curr_offset];
-                        if start_ch == b'\'' && postfix.iter().all(|x| *x == b'@') {
+                    // check for postfix '###
+                    if *ch == b'#' {
+                        let start_ch = input[curr_offset - prefix_sharp_cnt];
+                        let postfix = &input[curr_offset - prefix_sharp_cnt + 1..=curr_offset];
+                        if start_ch == b'\'' && postfix.iter().all(|x| *x == b'#') {
                             matches = true;
                             curr_offset += 1;
                             break;
@@ -558,7 +558,7 @@ fn lex_internal(
                     ));
                 } else if error.is_none() {
                     error = Some(ParseError::UnexpectedEof(
-                        "@".to_string(),
+                        "#".to_string(),
                         Span::new(span_offset + curr_offset, span_offset + curr_offset),
                     ))
                 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -67,7 +67,7 @@ pub fn is_math_expression_like(working_set: &mut StateWorkingSet, span: Span) ->
     let b = bytes[0];
 
     // check for raw string
-    if bytes.starts_with(b"r@") {
+    if bytes.starts_with(b"r#") {
         return true;
     }
 
@@ -1576,47 +1576,48 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
 
     let bytes = working_set.get_span_contents(span);
 
-    let prefix_at_cnt = if bytes.starts_with(b"r@") {
+    let prefix_sharp_cnt = if bytes.starts_with(b"r#") {
         // actually `at_cnt` is always `index - 1`
         // but create a variable here to make it clearer.
-        let mut at_cnt = 1;
+        let mut sharp_cnt = 1;
         let mut index = 2;
-        while index < bytes.len() && bytes[index] == b'@' {
+        while index < bytes.len() && bytes[index] == b'#' {
             index += 1;
-            at_cnt += 1;
+            sharp_cnt += 1;
         }
-        at_cnt
+        sharp_cnt
     } else {
-        working_set.error(ParseError::Expected("r@", span));
+        working_set.error(ParseError::Expected("r#", span));
         return garbage(span);
     };
-    let expect_postfix_at_cnt = prefix_at_cnt;
+    let expect_postfix_sharp_cnt = prefix_sharp_cnt;
     // check the length of whole raw string.
     // the whole raw string should contains at least
-    // 1(r) + prefix_at_cnt + 1(') + 1(') + postfix_at characters
-    if bytes.len() < prefix_at_cnt + expect_postfix_at_cnt + 3 {
+    // 1(r) + prefix_sharp_cnt + 1(') + 1(') + postfix_at characters
+    if bytes.len() < prefix_sharp_cnt + expect_postfix_sharp_cnt + 3 {
         working_set.error(ParseError::Unclosed('\''.into(), span));
         return garbage(span);
     }
 
-    // check for unbalanced @ and single quotes.
-    let postfix_bytes = &bytes[bytes.len() - expect_postfix_at_cnt..bytes.len()];
-    if postfix_bytes.iter().any(|b| *b != b'@') {
+    // check for unbalanced # and single quotes.
+    let postfix_bytes = &bytes[bytes.len() - expect_postfix_sharp_cnt..bytes.len()];
+    if postfix_bytes.iter().any(|b| *b != b'#') {
         working_set.error(ParseError::Unbalanced(
-            "prefix @".to_string(),
-            "postfix @".to_string(),
+            "prefix #".to_string(),
+            "postfix #".to_string(),
             span,
         ));
         return garbage(span);
     }
     // check for unblanaced single quotes.
-    if bytes[1 + prefix_at_cnt] != b'\'' || bytes[bytes.len() - expect_postfix_at_cnt - 1] != b'\''
+    if bytes[1 + prefix_sharp_cnt] != b'\''
+        || bytes[bytes.len() - expect_postfix_sharp_cnt - 1] != b'\''
     {
         working_set.error(ParseError::Unclosed('\''.into(), span));
         return garbage(span);
     }
 
-    let bytes = &bytes[prefix_at_cnt + 1 + 1..bytes.len() - 1 - prefix_at_cnt];
+    let bytes = &bytes[prefix_sharp_cnt + 1 + 1..bytes.len() - 1 - prefix_sharp_cnt];
     if let Ok(token) = String::from_utf8(bytes.into()) {
         Expression {
             expr: Expr::RawString(token),
@@ -4618,7 +4619,7 @@ pub fn parse_value(
                 return Expression::garbage(span);
             }
         },
-        b'r' if bytes.len() > 1 && bytes[1] == b'@' => {
+        b'r' if bytes.len() > 1 && bytes[1] == b'#' => {
             return parse_raw_string(working_set, span);
         }
         _ => {}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1577,7 +1577,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     let bytes = working_set.get_span_contents(span);
 
     let prefix_sharp_cnt = if bytes.starts_with(b"r#") {
-        // actually `at_cnt` is always `index - 1`
+        // actually `sharp_cnt` is always `index - 1`
         // but create a variable here to make it clearer.
         let mut sharp_cnt = 1;
         let mut index = 2;
@@ -1593,7 +1593,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     let expect_postfix_sharp_cnt = prefix_sharp_cnt;
     // check the length of whole raw string.
     // the whole raw string should contains at least
-    // 1(r) + prefix_sharp_cnt + 1(') + 1(') + postfix_at characters
+    // 1(r) + prefix_sharp_cnt + 1(') + 1(') + postfix_sharp characters
     if bytes.len() < prefix_sharp_cnt + expect_postfix_sharp_cnt + 3 {
         working_set.error(ParseError::Unclosed('\''.into(), span));
         return garbage(span);

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -80,7 +80,11 @@ fn raw_string() -> TestResult {
         r#"r###'abcde""fghi"'''##'#jkl'###"#,
         r#"abcde""fghi"'''##'#jkl"#,
     )?;
-    run_test("r#''#", "")
+    run_test("r#''#", "")?;
+    run_test(
+        r#"r#'a string with sharp inside # and ends with #'#"#,
+        "a string with sharp inside # and ends with #",
+    )
 }
 
 #[test]

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -74,16 +74,16 @@ fn case_insensitive_sort_columns() -> TestResult {
 
 #[test]
 fn raw_string() -> TestResult {
-    run_test(r#"r@'abcde""fghi"''''jkl'@"#, r#"abcde""fghi"''''jkl"#)?;
-    run_test(r#"r@@'abcde""fghi"''''@jkl'@@"#, r#"abcde""fghi"''''@jkl"#)?;
+    run_test(r#"r#'abcde""fghi"''''jkl'#"#, r#"abcde""fghi"''''jkl"#)?;
+    run_test(r#"r##'abcde""fghi"''''#jkl'##"#, r#"abcde""fghi"''''#jkl"#)?;
     run_test(
-        r#"r@@@'abcde""fghi"'''@@'@jkl'@@@"#,
-        r#"abcde""fghi"'''@@'@jkl"#,
+        r#"r###'abcde""fghi"'''##'#jkl'###"#,
+        r#"abcde""fghi"'''##'#jkl"#,
     )?;
-    run_test("r@''@", "")
+    run_test("r#''#", "")
 }
 
 #[test]
 fn incomplete_raw_string() -> TestResult {
-    fail_test("r@abc", "expected '")
+    fail_test("r#abc", "expected '")
 }

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -403,15 +403,15 @@ fn const_glob_type() {
 
 #[test]
 fn const_raw_string() {
-    let actual = nu!(r#"const x = r@'abcde""fghi"''''jkl'@; $x"#);
+    let actual = nu!(r#"const x = r#'abcde""fghi"''''jkl'#; $x"#);
     assert_eq!(actual.out, r#"abcde""fghi"''''jkl"#);
 
-    let actual = nu!(r#"const x = r@@'abcde""fghi"''''@jkl'@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"''''@jkl"#);
+    let actual = nu!(r#"const x = r##'abcde""fghi"''''#jkl'##; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"''''#jkl"#);
 
-    let actual = nu!(r#"const x = r@@@'abcde""fghi"'''@@'@jkl'@@@; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"'''@@'@jkl"#);
+    let actual = nu!(r#"const x = r###'abcde""fghi"'''##'#jkl'###; $x"#);
+    assert_eq!(actual.out, r#"abcde""fghi"'''##'#jkl"#);
 
-    let actual = nu!(r#"const x = r@'abc'@; $x"#);
+    let actual = nu!(r#"const x = r#'abc'#; $x"#);
     assert_eq!(actual.out, "abc");
 }


### PR DESCRIPTION
After today's meeting, we dicided to use `r#` instead of `r@`, and try the new syntax.

We can always change it before new release