### PR TITLE
Fix spread arguments in dynamic `%` dispatch

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1480,10 +1480,23 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             // Store the head expression for the IR compiler to pick up.
             call.set_parser_info(PERCENT_FORCED_BUILTIN_PARSER_INFO.to_string(), head_expr);
 
-            // Parse remaining spans as positional arguments.
+            // Parse remaining spans as positional arguments, with spread support.
             for arg_span in resolution_spans.iter().skip(head_idx + 1) {
-                let arg_expr = parse_value(working_set, *arg_span, &SyntaxShape::Any);
-                call.arguments.push(Argument::Positional(arg_expr));
+                let contents = working_set.get_span_contents(*arg_span);
+                if contents.len() > 3
+                    && contents.starts_with(b"...")
+                    && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')
+                {
+                    let spread_expr = parse_value(
+                        working_set,
+                        Span::new(arg_span.start + 3, arg_span.end),
+                        &SyntaxShape::List(Box::new(SyntaxShape::Any)),
+                    );
+                    call.arguments.push(Argument::Spread(spread_expr));
+                } else {
+                    let arg_expr = parse_value(working_set, *arg_span, &SyntaxShape::Any);
+                    call.arguments.push(Argument::Positional(arg_expr));
+                }
             }
 
             return Expression::new(


### PR DESCRIPTION
Commit 1810072 ("implement dynamic dispatch for % sigil") added runtime dispatch for `%($cmd)` / `%$cmd`, but the parser loop that handles trailing arguments only emitted `Argument::Positional`. It never checked for the `...` spread prefix, so `...$args` was parsed as a literal value and resolved as a file path at runtime:

    export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }
    builtin ls .
    # => Error: nu::shell::io::not_found
    # "/Users/.../nushell/...$args" does not exist

The fix mirrors how spread is detected everywhere else in the parser (internal calls, external calls, list/record literals): check whether the span starts with `...` followed by `$`, `[`, or `(`, strip the three-byte prefix, parse the remainder as `List(Any)`, and push `Argument::Spread` instead of `Argument::Positional`. The IR compiler already forwards spread arguments faithfully to `run-internal`, and `call.rest()` flattens them at runtime, so no other changes are needed.
